### PR TITLE
fix: change CLong to CInt

### DIFF
--- a/src/acoupipe/datasets/spectra_analytic.py
+++ b/src/acoupipe/datasets/spectra_analytic.py
@@ -5,12 +5,12 @@ from acoular.internal import digest
 from numpy import diag_indices, dot, r_, tril_indices, zeros
 from numpy.random import default_rng
 from scipy.linalg import cholesky
-from traits.api import CArray, CLong, Either, Float, Instance, Int, Property, Trait, cached_property, property_depends_on
+from traits.api import CArray, CInt, Either, Float, Instance, Int, Property, Trait, cached_property, property_depends_on
 
 
 class PowerSpectraAnalytic(PowerSpectraImport):
 
-    numsamples = CLong
+    numsamples = CInt
 
     sample_freq = Float(1.0,
         desc="sampling frequency")

--- a/src/acoupipe/loader.py
+++ b/src/acoupipe/loader.py
@@ -3,7 +3,7 @@ from os import path
 
 from acoular import config
 from h5py import File as H5File
-from traits.api import CLong, Dict, File, Instance, List, Property, cached_property, on_trait_change
+from traits.api import CInt, Dict, File, Instance, List, Property, cached_property, on_trait_change
 
 from acoupipe.pipeline import DataGenerator
 
@@ -44,7 +44,7 @@ class LoadH5Dataset(BaseLoadDataset):
         desc="basename of data file")
 
     #: Number of data samples, is set automatically / read from file.
-    numsamples = CLong(0,
+    numsamples = CInt(0,
         desc="number of samples in the dataset")
 
     #: Names of features, is set automatically / read from file.
@@ -52,7 +52,7 @@ class LoadH5Dataset(BaseLoadDataset):
         desc="names of the features in the dataset")
 
     #: Number of features, is set automatically / read from file.
-    numfeatures = CLong(0,
+    numfeatures = CInt(0,
         desc="number of features in the dataset")
 
     #: Number of features, is set automatically / read from file.


### PR DESCRIPTION
Running 
```python
from acoular.datasets import spectra_analytic 
```
fails with 
```bash
File "~/repos/acoupipe/.venv310/lib/python3.10/site-packages/acoupipe/datasets/spectra_analytic.py", line 8, in <module>
    from traits.api import CArray, CLong, Either, Float, Instance, Int, Property, Trait, cached_property, property_depends_on
ImportError: cannot import name 'CLong' from 'traits.api' (~/repos/acoupipe/.venv310/lib/python3.10/site-packages/traits/api.py)
```

The [official documentation](https://traits.readthedocs.io/en/stable/traits_api_reference/trait_types.html#traits.trait_types.CLong) of traits mentions:
> *`traits.trait_types.CLong = <class 'traits.trait_types.CInt'>`
    A trait whose value must be an integer and which supports coercions of non-integer values to integer, using a C-level fast validator. This is an alias for [CInt](https://traits.readthedocs.io/en/stable/traits_api_reference/trait_types.html#traits.trait_types.CInt). Use CInt instead.*

So I changed all occurrences of `CLong` to `CInt`.
