### PR TITLE
Squashed commit of the following:

### DIFF
--- a/src/acoupipe/__init__.py
+++ b/src/acoupipe/__init__.py
@@ -1,4 +1,4 @@
 """The AcouPipe module extends the computational pipeline-based concept of Acoular_ and provides additional tools that can be helpful to generate realizations of features in a predefined random process."""
 
 __author__ = 'Adam Kujawski, Art R. J. Pelling, Simon Jekosch, Ennes Sarradj'
-from .version import __version__
+from .version import __version__ as __version__

--- a/src/acoupipe/__init__.py
+++ b/src/acoupipe/__init__.py
@@ -1,4 +1,4 @@
 """The AcouPipe module extends the computational pipeline-based concept of Acoular_ and provides additional tools that can be helpful to generate realizations of features in a predefined random process."""
 
 __author__ = 'Adam Kujawski, Art R. J. Pelling, Simon Jekosch, Ennes Sarradj'
-__version__ = '24.04'
+from .version import __version__


### PR DESCRIPTION
The __init__.py had a hardcoded __version__ = '24.04' that was out of sync with version.py which defines __version__ = '25.05'. This caused a mismatch between the runtime version (acoupipe.__version__) and the package version.

Now __init__.py imports __version__ from .version, matching the approach used in Acoular and ensuring consistency.