### PR TITLE
Fix import sorting and Acoular-style import aliases

### DIFF
--- a/examples/micgeom_sampling_example.py
+++ b/examples/micgeom_sampling_example.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 
 import acoular as ac
+from acoupipe.sampler import MicGeomSampler
+
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy
 from numpy.random import RandomState
-
-from acoupipe.sampler import MicGeomSampler
 
 nsamples = 10
 

--- a/examples/numeric_attribute_sampling.py
+++ b/examples/numeric_attribute_sampling.py
@@ -5,11 +5,11 @@ Created on Tue Oct 13 11:53:22 2020.
 @author: kujawski
 """
 
+from acoular import WNoiseGenerator
+from acoupipe.sampler import NumericAttributeSampler
+
 import matplotlib.pyplot as plt
 import scipy.stats
-from acoular import WNoiseGenerator
-
-from acoupipe.sampler import NumericAttributeSampler
 
 # create white noise signal
 wn = WNoiseGenerator(sample_freq=51200, seed=10, rms=1.0, num_samples=51200)

--- a/examples/pipeline_writeH5_example.py
+++ b/examples/pipeline_writeH5_example.py
@@ -8,20 +8,20 @@ on the second evaluation of this script.
 import sys
 from os import path
 
-import acoular
-import numpy as np
-import scipy
-
+import acoular as ac
 from acoupipe.loader import LoadH5Dataset
 from acoupipe.pipeline import BasePipeline
 from acoupipe.sampler import NumericAttributeSampler
 from acoupipe.writer import WriteH5Dataset
 
+import numpy as np
+import scipy
+
 # float_list_feature, float_feature, int64_feature #WriteTFRecord
 
 ####################global######################
-acoular.config.h5library = 'h5py'
-acoular.config.global_caching = 'none'
+ac.config.h5library = 'h5py'
+ac.config.global_caching = 'none'
 DATASET_NAME = 'example_hdfdata_format.h5'
 ################################################
 
@@ -31,19 +31,19 @@ rng = np.random.RandomState(1)  # scipy listens to numpy random seed (when scipy
 rayleigh_dist = scipy.stats.rayleigh(scale=5.0)
 
 # create white noise signal
-wn = acoular.WNoiseGenerator(sample_freq=51200, seed=10, rms=1.0, num_samples=51200)
+wn = ac.WNoiseGenerator(sample_freq=51200, seed=10, rms=1.0, num_samples=51200)
 
 # create sampler object to sample rms value with rayleigh distribution
 rms_sampling = NumericAttributeSampler(random_var=rayleigh_dist, target=[wn], attribute='rms', random_state=rng)
 
 # build processing chain
-micgeofile = path.join(path.split(acoular.__file__)[0], 'xml', 'array_64.xml')
-mg = acoular.MicGeom(file=micgeofile)
-p1 = acoular.PointSource(signal=wn, mics=mg)
-ps = acoular.PowerSpectra(source=p1, block_size=128, window='Hanning')
-rg = acoular.RectGrid(x_min=-0.2, x_max=0.2, y_min=-0.2, y_max=0.2, z=0.3, increment=0.01)
-st = acoular.SteeringVector(grid=rg, mics=mg)
-bb = acoular.BeamformerBase(freq_data=ps, steer=st)
+micgeofile = path.join(path.split(ac.__file__)[0], 'xml', 'array_64.xml')
+mg = ac.MicGeom(file=micgeofile)
+p1 = ac.PointSource(signal=wn, mics=mg)
+ps = ac.PowerSpectra(source=p1, block_size=128, window='Hanning')
+rg = ac.RectGrid(x_min=-0.2, x_max=0.2, y_min=-0.2, y_max=0.2, z=0.3, increment=0.01)
+st = ac.SteeringVector(grid=rg, mics=mg)
+bb = ac.BeamformerBase(freq_data=ps, steer=st)
 
 
 # create a feature extraction function

--- a/examples/point_source_example.py
+++ b/examples/point_source_example.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 
 import acoular as ac
+from acoupipe.sampler import NumericAttributeSampler, PointSourceSampler, SourceSetSampler
+
 import numpy as np
 import scipy.stats
 from pylab import colorbar, figure, imshow, plot, show
-
-from acoupipe.sampler import NumericAttributeSampler, PointSourceSampler, SourceSetSampler
 
 ac.config.global_caching = 'none'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,6 @@ extend-exclude = ["docs/source"]   # shared config's exclude resolves to its own
 [tool.ruff.lint]
 extend-ignore = [
     # ===== Temporary migration guards (removed in the noted sub-issue) =====
-    "I001", "F401", "E402", "PLR0402",   # 2   imports: sorting / unused / placement / from-import
-    "ICN001", "ICN003",                  # 2   import aliases
     # E501 / W505 (line-length, doc-length) live in per-file src entries -> 3-8, peelable per module
     "G004", "LOG015",                    # 11  logging
     "PGH004", "RUF100", "E741",          # 10  stale-noqa cleanup / ambiguous names

--- a/src/acoupipe/datasets/base.py
+++ b/src/acoupipe/datasets/base.py
@@ -3,18 +3,18 @@
 import logging
 from functools import partial
 
-from traits.api import Dict, HasPrivateTraits, Instance, Int, Property
-
 from acoupipe.config import TF_FLAG
 from acoupipe.datasets.features import BaseFeatureCatalog, BaseFeatureCollectionBuilder
 from acoupipe.datasets.utils import set_pipeline_seeds
 from acoupipe.pipeline import BasePipeline, DistributedPipeline
 from acoupipe.writer import WriteH5Dataset
 
-if TF_FLAG:
-    import tensorflow as tf
+from traits.api import Dict, HasPrivateTraits, Instance, Int, Property
 
+if TF_FLAG:
     from acoupipe.writer import WriteTFRecord, complex_list_feature
+
+    import tensorflow as tf
 
 
 class ConfigBase(HasPrivateTraits):
@@ -310,9 +310,9 @@ class DatasetBase(HasPrivateTraits):
 
 
 if TF_FLAG:
-    import tensorflow as tf
-
     from acoupipe.writer import WriteTFRecord, complex_list_feature
+
+    import tensorflow as tf
 
     def save_tfrecord(self, features, size, name, split='training', f=None, num=0, start_idx=0, progress_bar=True):
         """Save dataset to a .tfrecord file.

--- a/src/acoupipe/datasets/experimental.py
+++ b/src/acoupipe/datasets/experimental.py
@@ -18,16 +18,16 @@ from functools import partial
 from pathlib import Path
 
 import acoular as ac
-import h5py as h5
-import numpy as np
-from irdl import MiracleDataset, SrirachaDataset
-from traits.api import Dict, Either, Enum, Instance, Int, Property, Str, observe
-
 from acoupipe.datasets.base import DatasetBase
 from acoupipe.datasets.synthetic import DatasetSyntheticConfig
 from acoupipe.datasets.utils import (
     calc_transfer,
 )
+
+import h5py as h5
+import numpy as np
+from irdl import MiracleDataset, SrirachaDataset
+from traits.api import Dict, Either, Enum, Instance, Int, Property, Str, observe
 
 _MIRACLE_SCENARIOS = ['A1', 'D1', 'A2', 'R2']
 _SRIRACHA_SCENARIOS = [

--- a/src/acoupipe/datasets/features.py
+++ b/src/acoupipe/datasets/features.py
@@ -1,11 +1,6 @@
 from functools import partial
 
 import acoular as ac
-import numpy as np
-from numpy import array, imag, newaxis, real, triu_indices
-from numpy.linalg import eigh
-from traits.api import Callable, Dict, Either, Enum, Float, HasPrivateTraits, Instance, Int, List, Property, Str, Tuple
-
 from acoupipe.config import TF_FLAG
 from acoupipe.datasets.spectra_analytic import PowerSpectraAnalytic
 from acoupipe.datasets.utils import (
@@ -13,6 +8,10 @@ from acoupipe.datasets.utils import (
     get_point_sources_recursively,
     get_uncorrelated_noise_source_recursively,
 )
+
+import numpy as np
+from numpy.linalg import eigh
+from traits.api import Callable, Dict, Either, Enum, Float, HasPrivateTraits, Instance, Int, List, Property, Str, Tuple
 
 if TF_FLAG:
     from acoupipe.writer import infer_tf_encoding
@@ -172,13 +171,13 @@ class SourcemapFeature(BaseFeatureCatalog):
 
     @staticmethod
     def calc_beamformer1(sampler, beamformer, f, num, name):
-        sm = array([beamformer.synthetic(freq, num=num) for freq in f])
+        sm = np.array([beamformer.synthetic(freq, num=num) for freq in f])
         return {name: sm}
 
     @staticmethod
     def calc_beamformer2(sampler, beamformer, name):
         f = beamformer.freq_data.fftfreq()
-        sm = array([beamformer.synthetic(freq, num=0) for freq in f])
+        sm = np.array([beamformer.synthetic(freq, num=0) for freq in f])
         return {name: sm}
 
     def get_feature_func(self):
@@ -330,7 +329,7 @@ class CSMFeature(SpectraFeature):
             depending on the number of frequencies in fidx.
         """
         csm = freq_data.csm[:]
-        csm = array([csm[indices[0] : indices[1]].sum(0) for indices in fidx], dtype=complex)
+        csm = np.array([csm[indices[0] : indices[1]].sum(0) for indices in fidx], dtype=complex)
         return {name: csm}
 
     def get_feature_func(self):
@@ -351,10 +350,10 @@ class CSMtriuFeature(SpectraFeature):
         csm_triu_imag = np.zeros(csm.shape)
         num_mics = csm.shape[1]
         for i in range(csm.shape[0]):
-            csmtriu_real[i][triu_indices(num_mics)] = real(csm[i])[
-                triu_indices(num_mics)
+            csmtriu_real[i][np.triu_indices(num_mics)] = np.real(csm[i])[
+                np.triu_indices(num_mics)
             ]  # add real part at upper triangular matrix
-            csm_triu_imag[i][triu_indices(num_mics)] = imag(csm[i])[triu_indices(num_mics)]
+            csm_triu_imag[i][np.triu_indices(num_mics)] = np.imag(csm[i])[np.triu_indices(num_mics)]
         return csmtriu_real + csm_triu_imag.transpose(0, 2, 1)
 
     @staticmethod
@@ -393,7 +392,7 @@ class CSMtriuFeature(SpectraFeature):
             depending on the number of frequencies in fidx.
         """
         csm = freq_data.csm[:]
-        csm = array([csm[indices[0] : indices[1]].sum(0) for indices in fidx], dtype=complex)
+        csm = np.array([csm[indices[0] : indices[1]].sum(0) for indices in fidx], dtype=complex)
         return {name: CSMtriuFeature.transform(csm)}
 
     def get_feature_func(self):
@@ -410,7 +409,7 @@ class EigmodeFeature(SpectraFeature):
     @staticmethod
     def transform(csm):
         eva, eve = eigh(csm)
-        return eva[:, newaxis, :] * eve[:]
+        return eva[:, np.newaxis, :] * eve[:]
 
     @staticmethod
     def calc_eigmode1(sampler, freq_data, name):
@@ -448,7 +447,7 @@ class EigmodeFeature(SpectraFeature):
             depending on the number of frequencies in fidx.
         """
         csm = freq_data.csm[:]
-        csm = array([csm[indices[0] : indices[1]].sum(0) for indices in fidx], dtype=complex)
+        csm = np.array([csm[indices[0] : indices[1]].sum(0) for indices in fidx], dtype=complex)
         return {name: EigmodeFeature.transform(csm)}
 
     def get_feature_func(self):

--- a/src/acoupipe/datasets/spectra_analytic.py
+++ b/src/acoupipe/datasets/spectra_analytic.py
@@ -1,10 +1,9 @@
-import numpy as np
-import numpy.fft as fft
 from acoular import PowerSpectraImport, SteeringVector
 from acoular.internal import digest
-from numpy import diag_indices, dot, r_, tril_indices, zeros
+
+import numpy as np
+import scipy.linalg as spla
 from numpy.random import default_rng
-from scipy.linalg import cholesky
 from traits.api import (
     CArray,
     CInt,
@@ -138,7 +137,7 @@ class PowerSpectraAnalytic(PowerSpectraImport):
         f : ndarray
             Array of length *block_size/2+1* containing the sample frequencies.
         """
-        return abs(fft.fftfreq(self.block_size, 1.0 / self.sample_freq)[: int(self.block_size / 2 + 1)])
+        return abs(np.fft.fftfreq(self.block_size, 1.0 / self.sample_freq)[: int(self.block_size / 2 + 1)])
 
     @property_depends_on('num_samples, block_size, overlap')
     def _get_num_blocks(self):
@@ -173,19 +172,19 @@ class PowerSpectraAnalytic(PowerSpectraImport):
         df = self.df_eq
         dim = scale.shape[0]
         n_tril = dim * (dim - 1) // 2
-        C = cholesky(scale, lower=True)
+        C = spla.cholesky(scale, lower=True)
         covariances = rng.normal(size=n_tril) + 1j * rng.normal(size=n_tril)
         covariances *= np.sqrt(0.5)
-        variances = r_[[rng.gamma(df - dim + i, scale=1, size=1) ** 0.5 for i in range(dim)]]
-        A = zeros(C.shape, dtype=complex)
+        variances = np.r_[[rng.gamma(df - dim + i, scale=1, size=1) ** 0.5 for i in range(dim)]]
+        A = np.zeros(C.shape, dtype=complex)
         # input the covariances
-        tril_idx = tril_indices(dim, k=-1)
+        tril_idx = np.tril_indices(dim, k=-1)
         A[tril_idx] = covariances
         # Input the variances
-        A[diag_indices(dim)] = variances.astype(complex)[:, 0]
+        A[np.diag_indices(dim)] = variances.astype(complex)[:, 0]
         # build matrix
-        CA = dot(C, A)
-        return dot(CA, CA.conjugate().T) / df
+        CA = np.dot(C, A)
+        return np.dot(CA, CA.conjugate().T) / df
 
     @property_depends_on(
         'seed, mode, block_size, overlap, sample_freq, num_samples, Q, noise, ind_low, ind_high, steer.digest, custom_transfer',
@@ -200,7 +199,7 @@ class PowerSpectraAnalytic(PowerSpectraImport):
     def _calc_csm(self):
         Q = self._Q
         fftfreq = self.fftfreq()
-        H = zeros((fftfreq.shape[0], self.steer.mics.num_mics, Q.shape[1]), dtype=complex)
+        H = np.zeros((fftfreq.shape[0], self.steer.mics.num_mics, Q.shape[1]), dtype=complex)
         for i in self.indices:  # calculate only the indices that are needed
             H[i] = self.steer.transfer(fftfreq[i]).T  # transfer functions
         csm = H @ Q @ H.swapaxes(2, 1).conjugate()
@@ -221,7 +220,7 @@ class PowerSpectraAnalytic(PowerSpectraImport):
         if self.mode == 'analytic':
             return self.Q
         fftfreq = self.fftfreq()
-        Q = zeros((fftfreq.shape[0], self.Q.shape[1], self.Q.shape[1]), dtype=complex)
+        Q = np.zeros((fftfreq.shape[0], self.Q.shape[1], self.Q.shape[1]), dtype=complex)
         for i in self.indices:
             rng = default_rng([self.seed, i])
             Q[i] = self._sample_wishart(self.Q[i], rng)
@@ -233,7 +232,7 @@ class PowerSpectraAnalytic(PowerSpectraImport):
             if self.mode == 'analytic':
                 return self.noise
             fftfreq = self.fftfreq()
-            noise = zeros((fftfreq.shape[0], self.noise.shape[1], self.noise.shape[1]), dtype=complex)
+            noise = np.zeros((fftfreq.shape[0], self.noise.shape[1], self.noise.shape[1]), dtype=complex)
             for i in self.indices:
                 rng = default_rng([self.seed + 1, i])
                 noise[i] = self._sample_wishart(self.noise[i], rng)

--- a/src/acoupipe/datasets/synthetic.py
+++ b/src/acoupipe/datasets/synthetic.py
@@ -18,10 +18,6 @@ from copy import deepcopy
 from functools import partial
 
 import acoular as ac
-import numpy as np
-from scipy.stats import norm, poisson
-from traits.api import Bool, Dict, Enum, Float, Instance, Int, List, observe
-
 import acoupipe.sampler as sp
 from acoupipe.datasets.base import ConfigBase, DatasetBase
 from acoupipe.datasets.features import (
@@ -45,6 +41,10 @@ from acoupipe.datasets.ir import get_ir, require_ir_support
 from acoupipe.datasets.micgeom import tub_vogel64_ap1
 from acoupipe.datasets.spectra_analytic import PowerSpectraAnalytic
 from acoupipe.datasets.utils import calc_transfer, get_all_source_signals, get_uncorrelated_noise_source_recursively
+
+import numpy as np
+from scipy.stats import norm, poisson
+from traits.api import Bool, Dict, Enum, Float, Instance, Int, List, observe
 
 
 class DatasetSynthetic(DatasetBase):

--- a/src/acoupipe/datasets/utils.py
+++ b/src/acoupipe/datasets/utils.py
@@ -2,11 +2,11 @@ from functools import wraps
 from time import time
 
 import acoular as ac
-import numpy as np
-import scipy.signal
-
 from acoupipe.config import TF_FLAG
 from acoupipe.writer import WriteH5Dataset
+
+import numpy as np
+import scipy.signal
 
 if TF_FLAG:
     from acoupipe.writer import WriteTFRecord
@@ -14,8 +14,6 @@ import logging
 from datetime import datetime
 from os.path import join
 from warnings import warn
-
-from numpy import concatenate, imag, newaxis, real, searchsorted
 
 
 def calc_transfer(ir, fs, blocksize, fftfreq, time_axis=-1):
@@ -238,7 +236,7 @@ def get_frequency_index_range(freq, f, num):
     """
     if num == 0:
         # single frequency line
-        ind = searchsorted(freq, f)
+        ind = np.searchsorted(freq, f)
         if ind >= len(freq):
             warn(
                 f'Queried frequency ({f:g} Hz) not in resolved frequency range. Returning zeros.',
@@ -263,8 +261,8 @@ def get_frequency_index_range(freq, f, num):
     else:
         f1 = f * 2.0 ** (-0.5 / num)
         f2 = f * 2.0 ** (+0.5 / num)
-    ind1 = searchsorted(freq, f1)
-    ind2 = searchsorted(freq, f2)
+    ind1 = np.searchsorted(freq, f1)
+    ind2 = np.searchsorted(freq, f2)
     if ind1 == ind2:
         warn(
             f'Queried frequency band ({f1:g} to {f2:g} Hz) does not '
@@ -330,7 +328,7 @@ def set_filename(writer, path='.', *args):
 def complex_to_real(func):
     def complex_to_real_wrapper(*args, **kwargs):
         a = func(*args, **kwargs)
-        return concatenate([real(a)[..., newaxis], imag(a)[..., newaxis]], axis=-1)
+        return np.concatenate([np.real(a)[..., np.newaxis], np.imag(a)[..., np.newaxis]], axis=-1)
 
     return complex_to_real_wrapper
 

--- a/src/acoupipe/loader.py
+++ b/src/acoupipe/loader.py
@@ -4,10 +4,10 @@ import contextlib
 from os import path
 
 from acoular import config
+from acoupipe.base import DataGenerator
+
 from h5py import File as H5File
 from traits.api import CInt, Dict, File, Instance, List, Property, cached_property, on_trait_change
-
-from acoupipe.base import DataGenerator
 
 config.h5library = 'h5py'
 

--- a/src/acoupipe/pipeline.py
+++ b/src/acoupipe/pipeline.py
@@ -57,13 +57,13 @@ import os
 from functools import wraps
 from time import time
 
+from acoupipe.base import BaseSampler, DataGenerator
+
 import numpy as np
 import ray
 from numpy.random import RandomState, default_rng
 from tqdm import tqdm
 from traits.api import Callable, Dict, Either, Instance, Int, Property, Tuple
-
-from acoupipe.base import BaseSampler, DataGenerator
 
 
 # Without the use of this decorator factory (wraps), the name of the

--- a/src/acoupipe/sampler.py
+++ b/src/acoupipe/sampler.py
@@ -42,6 +42,8 @@ The output of the example is:
 from inspect import signature
 
 import acoular as ac
+from acoupipe.base import BaseSampler
+
 import numpy as np
 from numpy.random import Generator, RandomState
 from scipy.stats import _distn_infrastructure
@@ -63,8 +65,6 @@ from traits.api import (
     cached_property,
     observe,
 )
-
-from acoupipe.base import BaseSampler
 
 
 class NumericAttributeSampler(BaseSampler):

--- a/src/acoupipe/writer.py
+++ b/src/acoupipe/writer.py
@@ -21,13 +21,13 @@ The latter can be efficiently consumed by the Tensorflow framework for machine l
 from datetime import datetime
 from os import path
 
-import numpy as np
 from acoular import config
-from h5py import File as H5File
-from traits.api import Bool, Callable, Dict, File, Instance, List, Str, Trait
-
 from acoupipe.base import DataGenerator
 from acoupipe.config import TF_FLAG
+
+import numpy as np
+from h5py import File as H5File
+from traits.api import Bool, Callable, Dict, File, Instance, List, Str, Trait
 
 
 class BaseWriteDataset(DataGenerator):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,21 +4,22 @@ import tempfile
 from pathlib import Path
 
 from acoular import ImportGrid, SteeringVector
-import numpy as np
-import pytest
-from scipy.stats import norm
-
-from .constants import MIC_GEOM
-from .dummy_dataset import DatasetDummy
 from acoupipe.datasets.experimental import DatasetMIRACLE
 from acoupipe.datasets.spectra_analytic import PowerSpectraAnalytic
 from acoupipe.datasets.synthetic import DatasetSynthetic
 from acoupipe.sampler import ContainerSampler, LocationSampler, NumericAttributeSampler
-from tests.miracle_test_config import DatasetMIRACLETestConfig
-from tests.synthetic_test_config import DatasetSyntheticTestConfig
 from acoupipe.writer import WriteH5Dataset
 
+from tests.miracle_test_config import DatasetMIRACLETestConfig
+from tests.synthetic_test_config import DatasetSyntheticTestConfig
+
+from .constants import MIC_GEOM
+from .dummy_dataset import DatasetDummy
 from .pipeline_value_test import get_pipeline
+
+import numpy as np
+import pytest
+from scipy.stats import norm
 
 
 class _AttributeTarget:

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -4,8 +4,9 @@ This module centralizes constants that are used across multiple test files
 to avoid duplication and ensure consistency.
 """
 
-import numpy as np
 from acoular import MicGeom
+
+import numpy as np
 
 # Feature names that are implemented and tested
 IMPLEMENTED_FEATURES = [

--- a/tests/dummy_dataset.py
+++ b/tests/dummy_dataset.py
@@ -8,17 +8,14 @@ pipeline.
 """
 
 import hashlib
-import os
 import pickle
-from functools import partial
 from pathlib import Path
-
-import numpy as np
-from traits.api import Bool, Dict, Float, Instance, Int, List, Enum, Any
 
 from acoupipe.datasets.base import ConfigBase, DatasetBase
 from acoupipe.datasets.features import BaseFeatureCatalog, create_feature
 
+import numpy as np
+from traits.api import Bool, Dict, Enum, Float, Instance, Int
 
 # Default cache directory
 DEFAULT_CACHE_DIR = Path.home() / '.cache' / 'acoupipe' / 'dummy_dataset'
@@ -560,8 +557,7 @@ class DatasetDummy(DatasetBase):
             msg = 'TensorFlow is not available. Cannot save to TFRecord format.'
             raise ImportError(msg)
 
-        import tensorflow as tf
-        from acoupipe.writer import WriteTFRecord, complex_list_feature
+        from acoupipe.writer import WriteTFRecord
 
         # Get the feature collection to get the TF shape and dtype mappings
         feature_collection = self.get_feature_collection(features, f, num)
@@ -575,7 +571,8 @@ class DatasetDummy(DatasetBase):
 
         # Create a dummy pipeline that uses our generate method
         from acoupipe.base import DataGenerator
-        from traits.api import Any, Bool, Int, List, Str
+
+        from traits.api import Any, Int, List, Str
 
         class DummyPipeline(DataGenerator):
             # Define traits for the attributes we need
@@ -628,6 +625,7 @@ class DatasetDummy(DatasetBase):
         """
         from acoupipe.base import DataGenerator
         from acoupipe.writer import WriteH5Dataset
+
         from traits.api import Any, Int, List, Str
 
         # Create a dummy pipeline that uses our generate method
@@ -684,8 +682,8 @@ class DatasetDummy(DatasetBase):
             msg = 'TensorFlow is not available. Cannot create TF dataset.'
             raise ImportError(msg)
 
+
         import tensorflow as tf
-        from functools import partial
 
         # Get the feature collection to get the output signature
         feature_collection = self.get_feature_collection(features, f, num)

--- a/tests/miracle_test_config.py
+++ b/tests/miracle_test_config.py
@@ -4,9 +4,9 @@ This module contains test-specific configuration classes that should not be expo
 in the public API.
 """
 
-import numpy as np
-
 from acoupipe.datasets.experimental import DatasetMIRACLEConfig
+
+import numpy as np
 
 
 class DatasetMIRACLETestConfig(DatasetMIRACLEConfig):
@@ -119,6 +119,7 @@ class DatasetMIRACLETestConfig(DatasetMIRACLEConfig):
     def get_prepare_func(self):
         """Override to use DatasetSyntheticConfig's prepare functions."""
         from functools import partial
+
         from acoupipe.datasets.synthetic import DatasetSyntheticConfig
 
         cf = DatasetSyntheticConfig

--- a/tests/multiprocessing/conftest.py
+++ b/tests/multiprocessing/conftest.py
@@ -1,8 +1,8 @@
 import sys
 
-import pytest
-
 from tests.multiprocessing.pipeline_value_test import get_distributed_pipeline
+
+import pytest
 
 
 @pytest.fixture

--- a/tests/multiprocessing/pipeline_value_test.py
+++ b/tests/multiprocessing/pipeline_value_test.py
@@ -1,13 +1,14 @@
 """DistributedPipeline helpers for multiprocessing tests."""
 
 from acoular import MicGeom, PointSource, SourceMixer, WNoiseGenerator
-from numpy import array
-from numpy.random import RandomState
-from scipy.stats import norm, rayleigh
-
 from acoupipe.pipeline import DistributedPipeline
 from acoupipe.sampler import MicGeomSampler, NumericAttributeSampler, PointSourceSampler, SourceSetSampler
+
 from tests.constants import POS_TOTAL
+
+import numpy as np
+from numpy.random import RandomState
+from scipy.stats import norm, rayleigh
 
 
 def get_distributed_pipeline(nsamples=100, num_workers=1):
@@ -23,12 +24,12 @@ def get_distributed_pipeline(nsamples=100, num_workers=1):
         random_var=rayleigh(scale=5.0), target=wn_list, attribute='rms', random_state=RandomState(1)
     )
     mgs = MicGeomSampler(
-        random_var=norm(loc=0, scale=0.004), ddir=array([[1.0], [0.5], [0]]), random_state=RandomState(2), target=mg
+        random_var=norm(loc=0, scale=0.004), ddir=np.array([[1.0], [0.5], [0]]), random_state=RandomState(2), target=mg
     )
     pss = PointSourceSampler(
         random_var=norm(loc=0, scale=0.1688),
         target=ps_list,
-        ldir=array([[1.0], [1.0], [0.1]]),
+        ldir=np.array([[1.0], [1.0], [0.1]]),
         x_bounds=(-0.5, 0.5),
         y_bounds=(-0.5, 0.5),
         random_state=RandomState(3),

--- a/tests/multiprocessing/test_sampler.py
+++ b/tests/multiprocessing/test_sampler.py
@@ -1,7 +1,6 @@
-import pytest
-
 from acoupipe.pipeline import DistributedPipeline
 
+import pytest
 
 pytestmark = pytest.mark.multiprocessing
 

--- a/tests/pipeline_value_test.py
+++ b/tests/pipeline_value_test.py
@@ -1,13 +1,14 @@
 """BasePipeline and Distributed Pipeline for testing."""
 
 from acoular import MicGeom, PointSource, SourceMixer, WNoiseGenerator
-from numpy import array
-from numpy.random import RandomState
-from scipy.stats import norm, rayleigh
-
 from acoupipe.pipeline import BasePipeline
 from acoupipe.sampler import MicGeomSampler, NumericAttributeSampler, PointSourceSampler, SourceSetSampler
+
 from tests.constants import POS_TOTAL
+
+import numpy as np
+from numpy.random import RandomState
+from scipy.stats import norm, rayleigh
 
 
 def get_pipeline(nsamples):
@@ -24,13 +25,13 @@ def get_pipeline(nsamples):
     )
 
     mgs = MicGeomSampler(
-        random_var=norm(loc=0, scale=0.004), ddir=array([[1.0], [0.5], [0]]), random_state=RandomState(2), target=mg
+        random_var=norm(loc=0, scale=0.004), ddir=np.array([[1.0], [0.5], [0]]), random_state=RandomState(2), target=mg
     )
 
     pss = PointSourceSampler(
         random_var=norm(loc=0, scale=0.1688),
         target=ps_list,
-        ldir=array([[1.0], [1.0], [0.1]]),
+        ldir=np.array([[1.0], [1.0], [0.1]]),
         x_bounds=(-0.5, 0.5),
         y_bounds=(-0.5, 0.5),
         random_state=RandomState(3),

--- a/tests/regression/multiprocessing/test_datasets.py
+++ b/tests/regression/multiprocessing/test_datasets.py
@@ -1,9 +1,9 @@
 import os
 
+from tests.constants import MODES, START_IDX, TEST_SIGNAL_LENGTH
+
 import numpy as np
 import pytest
-
-from tests.constants import MODES, START_IDX, TEST_SIGNAL_LENGTH
 
 # tasks is defined locally in this file
 tasks = 2

--- a/tests/regression/test_datasets.py
+++ b/tests/regression/test_datasets.py
@@ -1,9 +1,10 @@
 import acoular as ac
+from acoupipe.datasets.experimental import DatasetMIRACLEConfig
+
+from tests.constants import FREQUENCIES, IMPLEMENTED_FEATURES, MODES, NUMS, START_IDX, TEST_SIGNAL_LENGTH
+
 import numpy as np
 import pytest
-
-from acoupipe.datasets.experimental import DatasetMIRACLEConfig
-from tests.constants import FREQUENCIES, IMPLEMENTED_FEATURES, MODES, NUMS, START_IDX, TEST_SIGNAL_LENGTH
 
 
 @pytest.mark.parametrize('mode', MODES)

--- a/tests/synthetic_test_config.py
+++ b/tests/synthetic_test_config.py
@@ -5,9 +5,9 @@ in the public API.
 """
 
 import acoular as ac
-import numpy as np
-
 from acoupipe.datasets.synthetic import DatasetSyntheticConfig
+
+import numpy as np
 
 
 class DatasetSyntheticTestConfig(DatasetSyntheticConfig):

--- a/tests/test_dataset_tf.py
+++ b/tests/test_dataset_tf.py
@@ -4,12 +4,12 @@ These tests verify that the pipeline-to-TensorFlow integration works correctly
 using the real dataset, as they test the actual pipeline implementation.
 """
 
-import numpy as np
-import pytest
-
 from acoupipe.datasets.synthetic import DatasetSynthetic
+
 from tests.constants import FREQUENCIES, IMPLEMENTED_FEATURES, MODES, NUMS
 from tests.synthetic_test_config import DatasetSyntheticTestConfig
+
+import pytest
 
 
 @pytest.fixture
@@ -28,8 +28,8 @@ def create_dataset():
 @pytest.fixture
 def temp_dir():
     """Create and clean up a temporary directory."""
-    import tempfile
     import shutil
+    import tempfile
     from pathlib import Path
 
     test_dir = Path(tempfile.mkdtemp())

--- a/tests/test_dummy_dataset.py
+++ b/tests/test_dummy_dataset.py
@@ -1,18 +1,18 @@
 """Tests for the dummy dataset functionality."""
 
-import os
 import importlib.util
-import tempfile
+import os
 import shutil
+import tempfile
 from pathlib import Path
+
+from .dummy_dataset import DatasetDummy, DatasetDummyConfig
 
 import numpy as np
 import pytest
 
 # Only run these tests if TensorFlow is available
 TF_FLAG = importlib.util.find_spec('tensorflow') is not None
-
-from .dummy_dataset import DatasetDummy, DatasetDummyConfig
 
 
 @pytest.fixture
@@ -322,7 +322,6 @@ class TestDummyDatasetWithTFRecord:
         """Test creating a TensorFlow dataset from dummy data."""
         if not TF_FLAG:
             pytest.skip('TensorFlow not available')
-        import tensorflow as tf
 
         features = ['csm', 'idx', 'seeds']
 

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1,8 +1,8 @@
 import importlib
 
-import pytest
-
 from acoupipe.datasets import ir
+
+import pytest
 
 
 def test_get_ir_falls_back_to_pyroomacoustics(monkeypatch):

--- a/tests/test_random_state.py
+++ b/tests/test_random_state.py
@@ -8,11 +8,10 @@ to the Sampler class, the random state of the random variable will be used.
 
 import unittest
 
+from acoupipe.base import BaseSampler
+
 from numpy.random import RandomState
 from scipy.stats import norm
-
-from acoupipe.base import BaseSampler
-from acoupipe.sampler import NumericAttributeSampler
 
 SEED = 100
 NVALUES = 100

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,13 +1,4 @@
 from acoular import MicGeom, PointSource, SourceMixer, WNoiseGenerator
-import numpy as np
-import pytest
-from numpy import array
-from numpy.random import RandomState, default_rng
-from numpy.testing import assert_almost_equal
-from scipy.spatial.distance import cdist
-from scipy.stats import norm
-
-from acoupipe.base import BaseSampler
 from acoupipe.pipeline import BasePipeline
 from acoupipe.sampler import (
     ContainerSampler,
@@ -17,6 +8,13 @@ from acoupipe.sampler import (
     SetSampler,
     SourceSetSampler,
 )
+
+import numpy as np
+import pytest
+from numpy.random import RandomState, default_rng
+from numpy.testing import assert_almost_equal
+from scipy.spatial.distance import cdist
+from scipy.stats import norm
 
 SAMPLER_CLASSES = [
     NumericAttributeSampler,
@@ -173,11 +171,11 @@ def test_micgeom_sampler(mode):
     rng = RandomState(2)
     normal_distribution = norm(loc=0, scale=0.1)
     if mode == 'deviate':
-        sampler = MicGeomSampler(random_var=normal_distribution, random_state=rng, ddir=array([[1.0], [1.0], [1.0]]))
+        sampler = MicGeomSampler(random_var=normal_distribution, random_state=rng, ddir=np.array([[1.0], [1.0], [1.0]]))
     elif mode == 'rotate':
-        sampler = MicGeomSampler(random_var=normal_distribution, random_state=rng, rvec=array([[1.0], [1.0], [1.0]]))
+        sampler = MicGeomSampler(random_var=normal_distribution, random_state=rng, rvec=np.array([[1.0], [1.0], [1.0]]))
     elif mode == 'translate':
-        sampler = MicGeomSampler(random_var=normal_distribution, random_state=rng, tdir=array([[1.0], [1.0], [1.0]]))
+        sampler = MicGeomSampler(random_var=normal_distribution, random_state=rng, tdir=np.array([[1.0], [1.0], [1.0]]))
 
     sampler.target = micgeom
     mpos_target = micgeom.pos_total.copy()

--- a/tests/test_save_h5.py
+++ b/tests/test_save_h5.py
@@ -4,10 +4,9 @@ These tests verify that HDF5 file saving works correctly, decoupled from
 acoustic correctness testing (which is done in regression tests).
 """
 
-import numpy as np
-import pytest
-
 from .dummy_dataset import DatasetDummy
+
+import pytest
 
 
 @pytest.fixture
@@ -19,8 +18,8 @@ def dummy_dataset():
 @pytest.fixture
 def temp_dir():
     """Create and clean up a temporary directory."""
-    import tempfile
     import shutil
+    import tempfile
     from pathlib import Path
 
     test_dir = Path(tempfile.mkdtemp())

--- a/tests/test_save_tfrecord.py
+++ b/tests/test_save_tfrecord.py
@@ -4,10 +4,10 @@ These tests verify that TFRecord file saving works correctly, decoupled from
 acoustic correctness testing (which is done in regression tests).
 """
 
+from .dummy_dataset import DatasetDummy
+
 import numpy as np
 import pytest
-
-from .dummy_dataset import DatasetDummy
 
 
 @pytest.fixture
@@ -19,8 +19,8 @@ def dummy_dataset():
 @pytest.fixture
 def temp_dir():
     """Create and clean up a temporary directory."""
-    import tempfile
     import shutil
+    import tempfile
     from pathlib import Path
 
     test_dir = Path(tempfile.mkdtemp())

--- a/tests/test_spectra.py
+++ b/tests/test_spectra.py
@@ -1,4 +1,5 @@
 from acoular import ImportGrid
+
 import numpy as np
 import pytest
 


### PR DESCRIPTION
Sorts imports and applies the banned-import aliases (np / nb / spla, acoular as ac) across the source modules, with the custom isort section-order keeping acoular imported before numpy/numba. The example files were linted for imports as well, even though the issue title only mentioned source files.

Closes #58 