### PR TITLE
Clean line-length and docstring-length findings in core modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,14 +119,12 @@ docstring-code-line-length = "dynamic"  # 3-8: Acoular uses 120; "dynamic" keeps
 [tool.ruff.lint.per-file-ignores]
 # In each src entry: E501/W505 -> the file's 3-8 line-length task; D* -> 9; N*/ARG*/SLF001 -> 10
 # --- src: 3 core modules ---
-"src/acoupipe/__init__.py"            = ["E501", "W505"]
 "src/acoupipe/base.py"                = ["D413"]
 "src/acoupipe/config.py"              = ["D100"]
 "src/acoupipe/version.py"             = ["D100"]
-"src/acoupipe/loader.py"              = ["D413", "E501", "W505"]
-"src/acoupipe/pipeline.py"            = ["D101", "D102", "D105", "D107", "D413", "E501", "W505"]
-"src/acoupipe/writer.py"              = ["D102", "D205", "D212", "D413", "E501", "W505"]
-"src/acoupipe/datasets/__init__.py"   = ["W505"]
+"src/acoupipe/loader.py"              = ["D413"]
+"src/acoupipe/pipeline.py"            = ["D101", "D102", "D105", "D107", "D413"]
+"src/acoupipe/writer.py"              = ["D102", "D205", "D212", "D413"]
 # --- src: 4 samplers ---
 "src/acoupipe/sampler.py"             = ["D101", "D102", "E501", "N806", "W505"]
 # --- src: 5 small dataset modules ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ extend-ignore = [
 ]
 
 [tool.ruff.format]
-docstring-code-line-length = "dynamic"  # 3-8: Acoular uses 120; "dynamic" keeps check passing during migration
+#docstring-code-line-length = 120
 
 [tool.ruff.lint.per-file-ignores]
 # In each src entry: E501/W505 -> the file's 3-8 line-length task; D* -> 9; N*/ARG*/SLF001 -> 10

--- a/src/acoupipe/__init__.py
+++ b/src/acoupipe/__init__.py
@@ -1,4 +1,8 @@
-"""The AcouPipe module extends the computational pipeline-based concept of Acoular_ and provides additional tools that can be helpful to generate realizations of features in a predefined random process."""
+"""The AcouPipe module extends the computational pipeline-based concept of Acoular_.
+
+It provides additional tools that can be helpful to generate realizations of features
+in a predefined random process.
+"""
 
 __author__ = 'Adam Kujawski, Art R. J. Pelling, Simon Jekosch, Ennes Sarradj'
 from .version import __version__ as __version__

--- a/src/acoupipe/datasets/__init__.py
+++ b/src/acoupipe/datasets/__init__.py
@@ -1,1 +1,1 @@
-"""The datasets subpackage contains default classes to create acoustical datasets with microphone array data."""
+"""Subpackage with default classes to create acoustical datasets with microphone array data."""

--- a/src/acoupipe/datasets/base.py
+++ b/src/acoupipe/datasets/base.py
@@ -294,9 +294,7 @@ class DatasetBase(HasPrivateTraits):
             num = 3
 
             # save the dataset
-            dataset = DatasetSynthetic().save_h5(
-                f=f, num=num, split='training', size=10, features=features, name='/tmp/example.h5'
-            )
+            dataset = DatasetSynthetic().save_h5(f=f, num=num, split='training', size=10, features=features, name='/tmp/example.h5')
         """
         pipeline = self.get_pipeline_instance()
         # self._setup_logging(pipeline=pipeline)

--- a/src/acoupipe/loader.py
+++ b/src/acoupipe/loader.py
@@ -1,4 +1,7 @@
-"""Provides classes to load the datasets stored with :class:`~acoupipe.writer.BaseWriteDataset` derived classes."""
+"""Provides classes to load the datasets stored with derived classes.
+
+See :class:`~acoupipe.writer.BaseWriteDataset`.
+"""
 
 import contextlib
 from os import path
@@ -13,7 +16,9 @@ config.h5library = 'h5py'
 
 
 class BaseLoadDataset(DataGenerator):
-    """Base class for all derived classes intended to load data stored by :class:`~acoupipe.writer.BaseWriteDataset`.
+    """Base class for all derived classes intended to load data.
+
+    Loads data stored by :class:`~acoupipe.writer.BaseWriteDataset`.
 
     This class has no functionality and should not be used.
     """
@@ -102,16 +107,16 @@ class LoadH5Dataset(BaseLoadDataset):
         a data generator with the :meth:`from_generator` method of the `Tensorflow Dataset API`_
         to feed machine learning models.
 
-        Example to create a repeatable data set with the Tensorflow `tf.data.Dataset` API is given in
+        Example to create a repeatable data set with the `tf.data.Dataset` API is given below:
 
         .. code-block:: python
 
             h5data = LoadH5Dataset(name='some_dataset.h5')
             generator = h5data.get_dataset_generator(features=['loc'])
-            output_signature = {
+            sig = {
                 'loc': tf.TensorSpec(shape=(3, None), dtype=tf.float32),
             }
-            dataset = tf.data.Dataset.from_generator(generator, output_signature=output_signature).repeat()
+            dataset = tf.data.Dataset.from_generator(generator, output_signature=sig).repeat()
             loc = next(iter(dataset))  # return locations
 
         Parameters
@@ -145,7 +150,7 @@ class LoadH5Dataset(BaseLoadDataset):
         return sample_generator
 
     def get_data(self):
-        """Python generator that iteratively yields the samples of the dataset in ascending sample index order (e.g. 1,2,...,N).
+        """Yield the dataset samples in ascending sample index order (e.g. 1,2,...,N).
 
         Returns
         -------

--- a/src/acoupipe/pipeline.py
+++ b/src/acoupipe/pipeline.py
@@ -3,11 +3,17 @@
 Purpose of the Pipeline Module
 ------------------------------
 
-Classes defined in the :code:`pipeline.py` module have the ability to iteratively perform tasks on the related computational pipeline to build up a dataset.
-The results of these tasks are the features (and labels) associated with a specific sample of the dataset.
-Feature creation tasks can be specified by passing callable functions that are evoked at each iteration of the :code:`BasePipeline`'s :code:`get_data()` generator method.
-It is worth noting that such a data generator can also be used directly to feed a machine learning model without saving the data to file, as common machine learning frameworks, such as Tensorflow_, offer the possibility to consume data from Python generators.
-Control of the state of the sampling process is maintained via the :code:`sampler` attribute holding a list of :code:`BaseSampler` derived instances.
+Classes defined in the :code:`pipeline.py` module have the ability to iteratively perform
+tasks on the related computational pipeline to build up a dataset.
+The results of these tasks are the features (and labels) associated with a specific
+sample of the dataset.
+Feature creation tasks can be specified by passing callable functions that are evoked at
+each iteration of the :code:`BasePipeline`'s :code:`get_data()` generator method.
+It is worth noting that such a data generator can also be used directly to feed a machine
+learning model without saving the data to file, as common machine learning frameworks,
+such as Tensorflow_, offer the possibility to consume data from Python generators.
+Control of the state of the sampling process is maintained via the :code:`sampler`
+attribute holding a list of :code:`BaseSampler` derived instances.
 
 .. code-block:: python
 
@@ -20,7 +26,7 @@ Control of the state of the sampling process is maintained via the :code:`sample
 
     n1 = ac.WNoiseGenerator(sample_freq=24000, numsamples=24000 * 5, rms=1.0, seed=1)
 
-    rms_sampler = NumericAttributeSampler(target=[n1], attribute='rms', random_var=random_var, random_state=10)
+    rms_sampler = NumericAttributeSampler(target=[n1], attribute='rms', random_var=random_var)
 
 
     def calculate_squared_rms(sampler):
@@ -86,7 +92,7 @@ def log_execution_time(f):
 
 
 class BasePipeline(DataGenerator):
-    """Class to control the random process and iteratively extract and pass a specified amount of data.
+    """Control the random process and iteratively extract and pass a specified amount of data.
 
     This class can be used to calculate data (extract features)
     by assigning a name and a callable function to :attr:`features`.
@@ -97,26 +103,34 @@ class BasePipeline(DataGenerator):
     """
 
     #: a dictionary with instances of :class:`~acoupipe.base.BaseSampler` derived classes as keys
-    #: alternatively, the dict can contain objects of type :class:`numpy.random._generator.Generator` or
-    #: :class:`numpy.random.RandomState` for control reasons
+    #: alternatively, the dict can contain objects of type
+    #: :class:`numpy.random._generator.Generator` or :class:`numpy.random.RandomState`
+    #: for control reasons
     #: (e.g. :code:`sampler = {0 : rms_sampler, 1 : numpy.random.RandomState(1)}`).
-    #: The trait also accepts a list of samples (e.g. :code:`sampler = [rms_sampler, numpy.random.RandomState(1)]`).
+    #: The trait also accepts a list of samples
+    #: (e.g. :code:`sampler = [rms_sampler, numpy.random.RandomState(1)]`).
     #: which is then converted to a dictionary with the indices of the list as keys.
     sampler = Property(
-        desc='Dictionary with instances of BaseSampler derived classes as values and their sample order indices as keys',
+        desc='Dictionary with instances of BaseSampler derived classes as values '
+        'and their sample order indices as keys',
     )
 
     #: feature method for the extraction/generation of features and labels.
-    #: one can either pass a callable (e.g. `features = `lambda sampler: {"feature_name" : sampler.target}`).
-    #: Note that the callable must accept a list of :class:`acoupipe.base.BaseSampler` objects as first argument.
+    #: one can either pass a callable
+    #: (e.g. `features = `lambda sampler: {"feature_name" : sampler.target}`).
+    #: Note that the callable must accept a list of :class:`acoupipe.base.BaseSampler`
+    #: objects as first argument.
     #: Alternatively, if further arguments are necessary, one can pass a tuple containing the
     #: callable and their arguments (e.g.: `features = (some_func, arg1, arg2, ...)}`).
     features = Either(Callable, Tuple, desc='feature method for the extraction/generation of features and labels')
 
     #: a dict with values of `range(seeds)` associated with sampler objects in :attr:`sampler`.
-    #: A new seed will be collected from each range object during an evaluation of the :meth:`get_data()` generator.
-    #: This seed is used to initialize an instance of :class:`numpy.random._generator.Generator` which is passed to
-    #: the :attr:`random_state` of the samplers in :attr:`sampler`. If not given, :meth:`get_data()` relies on
+    #: A new seed will be collected from each range object during an evaluation
+    #: of the :meth:`get_data()` generator.
+    #: This seed is used to initialize an instance of
+    #: :class:`numpy.random._generator.Generator` which is passed to
+    #: the :attr:`random_state` of the samplers in :attr:`sampler`.
+    #: If not given, :meth:`get_data()` relies on
     #: :attr:`numsamples`.
     random_seeds = Property(desc='Dictionary of seeds associated with sampler objects')
 
@@ -185,7 +199,7 @@ class BasePipeline(DataGenerator):
         raise ValueError(msg)
 
     def _update_sample_index_and_seeds(self, seed_iter=None):
-        """Update seeds and running index of associated with the current data sample of the dataset."""
+        """Update seeds and running index for the current data sample of the dataset."""
         self._idx += 1
         if not self.random_seeds:
             return
@@ -193,7 +207,8 @@ class BasePipeline(DataGenerator):
         for k in self.sampler:
             if isinstance(self.sampler[k], BaseSampler):
                 self.sampler[k].random_state = default_rng(self._seeds[k])
-                # self.logger.error(f"update {self.sampler[k].__class__.__name__}, state: {self.sampler[k].random_state.__getstate__()}")
+                # self.logger.error(f"update {self.sampler[k].__class__.__name__}, "
+                #     f"state: {self.sampler[k].random_state.__getstate__()}")
             elif isinstance(self.sampler[k], RandomState):
                 self.sampler[k].seed(self._seeds[k])
             elif isinstance(self.sampler[k], np.random.Generator):
@@ -308,7 +323,7 @@ class SamplerActor:
         self.sampler_order.sort()
 
     def sample(self, seeds):
-        """Invocation of the :meth:`sample` function of one or more :class:`BaseSampler` instances."""
+        """Invoke the :meth:`sample` function of one or more :class:`BaseSampler` instances."""
         self.set_new_seed(seeds)
         for k in self.sampler_order:
             if isinstance(self.sampler[k], BaseSampler):
@@ -372,7 +387,8 @@ class DistributedPipeline(BasePipeline):
     #: each worker is associated with a stateless task.
     numworkers = Int(1, desc='number of tasks to be performed in parallel (usually number of CPUs)')
 
-    #: additional arguments to be passed to ray remote tasks, e.g. num_gpus for GPU resource allocation (e.g. num_gpus=0.25 for 1 GPU per 4 tasks)
+    #: additional arguments to be passed to ray remote tasks, e.g. num_gpus for GPU
+    #: resource allocation (e.g. num_gpus=0.25 for 1 GPU per 4 tasks)
     remote_args = Dict()
 
     def _log_execution_time(self, task_index, times, pid):
@@ -398,7 +414,7 @@ class DistributedPipeline(BasePipeline):
         )  # add index, and seeds
 
     def _update_sample_index_and_seeds(self, seed_iter=None):
-        """Update seeds and running index of associated with the current data sample of the dataset."""
+        """Update seeds and running index for the current data sample of the dataset."""
         self._idx += 1
         if not self.random_seeds:
             return

--- a/src/acoupipe/writer.py
+++ b/src/acoupipe/writer.py
@@ -1,9 +1,10 @@
-"""Provides classes to store the data extracted by :class:`~acoupipe.pipeline.BasePipeline` derived classes.
+"""Provides classes to store the data extracted by :class:`~acoupipe.pipeline.BasePipeline`.
 
 Purpose of the Writer Module
 ----------------------------
 The :code:`writer.py` module provides classes to store the data extracted by the pipeline.
-The current implementation includes classes to save data in a container-like file format (.h5 file with the :code:`WriteH5Dataset` class) or
+The current implementation includes classes to save data in a container-like file format
+(.h5 file with the :code:`WriteH5Dataset` class) or
 binary format (.tfrecord file with the :code:`WriteTFRecord` class).
 The latter can be efficiently consumed by the Tensorflow framework for machine learning.
 
@@ -31,7 +32,9 @@ from traits.api import Bool, Callable, Dict, File, Instance, List, Str, Trait
 
 
 class BaseWriteDataset(DataGenerator):
-    """Base class intended to write data from :class:`~acoupipe.pipeline.BasePipeline` instances to a specific file format.
+    """Base class intended to write data to a specific file format.
+
+    Writes data from :class:`~acoupipe.pipeline.BasePipeline` instances.
 
     This class has no functionality and should not be used.
     """
@@ -40,11 +43,11 @@ class BaseWriteDataset(DataGenerator):
     source = Instance(DataGenerator)
 
     def save(self):
-        """Save data from a :class:`~acoupipe.pipeline.BasePipeline` instance specified at :attr:`source` to file."""
+        """Save data from the :attr:`source` instance to file."""
         # write to File...
 
     def get_data(self, progress_bar=True, start_idx=1):
-        """Python generator that saves source output data to file and passes the data to the next object.
+        """Save source output data to file and pass the data to the next object.
 
         Parameters
         ----------
@@ -115,7 +118,7 @@ class WriteH5Dataset(BaseWriteDataset):
                 f5h.create_dataset(f'metadata/{key}', data=value)
 
     def save(self, progress_bar=True, start_idx=1):
-        """Save the output of the :meth:`get_data()` method of :class:`~acoupipe.pipeline.BasePipeline` to .h5 file format."""
+        """Save the :meth:`get_data()` output of the :attr:`source` to .h5 file format."""
         f5h = self.get_file()
         subf = self.get_filtered_features()
         for data in self.source.get_data(progress_bar, start_idx):
@@ -125,7 +128,7 @@ class WriteH5Dataset(BaseWriteDataset):
         f5h.close()
 
     def get_data(self, progress_bar=True, start_idx=1):
-        """Python generator that saves the data passed by the source to a `*.h5` file and yields the data to the next object.
+        """Save the source data to a `*.h5` file and yield it to the next object.
 
         Returns
         -------
@@ -241,16 +244,18 @@ if TF_FLAG:
 
         Serializes samples from a :class:`~acoupipe.pipeline.BasePipeline` into the TensorFlow
         TFRecord format, using encoder functions provided via :attr:`encoder_funcs`.
-        For features whose shapes may vary (contain ``None``), list their names in :attr:`shape_features`
+        For features whose shapes may vary (contain ``None``), list their names
+        in :attr:`shape_features`
         to have the runtime shape stored as an auxiliary ``<name>_shape`` int64 feature.
         """
 
         #: Name of the file to be saved.
         name = File(filter=['*.tfrecords'], desc='name of data file')
 
-        #: Dictionary with encoding functions (dict values) to convert data yielded by the pipeline to binary .tfrecord format.
-        #: The key values of this dictionary are the feature names specified in the :attr:`features` attribute
-        #: of the :attr:`source` object.
+        #: Dictionary with encoding functions (dict values) to convert data yielded
+        #: by the pipeline to binary .tfrecord format.
+        #: The key values of this dictionary are the feature names specified
+        #: in the :attr:`features` attribute of the :attr:`source` object.
         encoder_funcs = Dict(
             key_trait=Str(),
             value_trait=Callable(),
@@ -260,7 +265,8 @@ if TF_FLAG:
         #: Trait to set specific options to the .tfrecord file.
         options = Trait(None, tf.io.TFRecordOptions)
 
-        #: List of feature names for which the shape should be stored alongside the data (as ``<name>_shape``).
+        #: List of feature names for which the shape should be stored alongside
+        #: the data (as ``<name>_shape``).
         shape_features = List(Str, desc='features whose shapes are written along with the data')
 
         def _encode_sample(self, features, encoders):

--- a/tests/dummy_dataset.py
+++ b/tests/dummy_dataset.py
@@ -682,7 +682,6 @@ class DatasetDummy(DatasetBase):
             msg = 'TensorFlow is not available. Cannot create TF dataset.'
             raise ImportError(msg)
 
-
         import tensorflow as tf
 
         # Get the feature collection to get the output signature


### PR DESCRIPTION
Reflows over-long docstrings and comments (W505) and code lines (E501) in the core modules (__init__, loader, pipeline, writer) to satisfy the 100/120 limits, and removes the corresponding E501/W505 per-file guards. Docstring code-block examples were shortened (rather than wrapped) since ruff's docstring formatter rejoins wrapped lines.

Closes #60 