### PR TITLE
Clean line-length and docstring-length findings in small dataset modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,9 +128,9 @@ extend-ignore = [
 # --- src: 4 samplers ---
 "src/acoupipe/sampler.py"             = ["D101", "D102", "E501", "N806", "W505"]
 # --- src: 5 small dataset modules ---
-"src/acoupipe/datasets/base.py"       = ["D102", "D107", "D212", "D413", "D417", "E501", "W505"]
+"src/acoupipe/datasets/base.py"       = ["D102", "D107", "D212", "D413", "D417"]
 "src/acoupipe/datasets/micgeom.py"    = ["D100"]
-"src/acoupipe/datasets/utils.py"      = ["D100", "D103", "D205", "D212", "D413", "N806", "W505"]
+"src/acoupipe/datasets/utils.py"      = ["D100", "D103", "D205", "D212", "D413", "N806"]
 # --- src: 6 feature extraction ---
 "src/acoupipe/datasets/features.py"   = ["ARG001", "ARG004", "D100", "D101", "D102", "D103", "D212", "D413", "D417", "E501", "SLF001", "W505"]
 # --- src: 7 synthetic datasets ---

--- a/src/acoupipe/datasets/base.py
+++ b/src/acoupipe/datasets/base.py
@@ -21,7 +21,7 @@ class ConfigBase(HasPrivateTraits):
     """Configuration base class for generating microphone array datasets."""
 
     def get_sampler(self):
-        """Return dictionary containing the sampler objects of type :class:`acoupipe.base.BaseSampler`.
+        """Return a dict of the sampler objects of type :class:`acoupipe.base.BaseSampler`.
 
         this function has to be manually defined in a dataset subclass.
         It includes the sampler objects as values. The key defines the idx in the sample order.
@@ -189,13 +189,15 @@ class DatasetBase(HasPrivateTraits):
         Parameters
         ----------
         features : list
-            List of features included in the dataset. The features "seeds" and "idx" are always included.
+            List of features included in the dataset.
+            The features "seeds" and "idx" are always included.
         split : str
             Split name for the dataset ('training', 'validation' or 'test'). Defaults to 'training'.
         size : int
             Size of the dataset (number of source cases).
         f : float
-            The center frequency or list of frequencies of the dataset. If None, all frequencies are included.
+            The center frequency or list of frequencies of the dataset.
+            If None, all frequencies are included.
         num : integer
             Controls the width of the frequency bands considered; defaults to
             0 (single frequency line).
@@ -216,7 +218,8 @@ class DatasetBase(HasPrivateTraits):
         Yields
         ------
         data : dict
-            Generator that yields dataset samples as dictionaries containing the feature names as keys.
+            Generator that yields dataset samples as dictionaries containing the feature
+            names as keys.
 
         Examples
         --------
@@ -232,7 +235,13 @@ class DatasetBase(HasPrivateTraits):
             num = 3
 
             # generate the dataset
-            generator = DatasetSynthetic().generate(f=f, num=num, split='training', size=2, features=features)
+            generator = DatasetSynthetic().generate(
+                f=f,
+                num=num,
+                split='training',
+                size=2,
+                features=features,
+            )
 
             # iterate over the dataset
             for data in generator:
@@ -250,7 +259,8 @@ class DatasetBase(HasPrivateTraits):
         Parameters
         ----------
         features : list
-            List of features included in the dataset. The features "seeds" and "idx" are always included.
+            List of features included in the dataset.
+            The features "seeds" and "idx" are always included.
         size : int
             Size of the dataset (number of source cases).
         name : str
@@ -258,7 +268,8 @@ class DatasetBase(HasPrivateTraits):
         split : str
             Split name for the dataset ('training', 'validation' or 'test'). Defaults to 'training'.
         f : float
-            The center frequency or list of frequencies of the dataset. If None, all frequencies are included.
+            The center frequency or list of frequencies of the dataset.
+            If None, all frequencies are included.
         num : integer
             Controls the width of the frequency bands considered; defaults to
             0 (single frequency line).
@@ -294,7 +305,14 @@ class DatasetBase(HasPrivateTraits):
             num = 3
 
             # save the dataset
-            dataset = DatasetSynthetic().save_h5(f=f, num=num, split='training', size=10, features=features, name='/tmp/example.h5')
+            dataset = DatasetSynthetic().save_h5(
+                f=f,
+                num=num,
+                split='training',
+                size=10,
+                features=features,
+                name='/tmp/example.h5',
+            )
         """
         pipeline = self.get_pipeline_instance()
         # self._setup_logging(pipeline=pipeline)
@@ -318,7 +336,8 @@ if TF_FLAG:
         Parameters
         ----------
         features : list
-            List of features included in the dataset. The features "seeds" and "idx" are always included.
+            List of features included in the dataset.
+            The features "seeds" and "idx" are always included.
         size : int
             Size of the dataset (number of source cases).
         name : str
@@ -326,7 +345,8 @@ if TF_FLAG:
         split : str
             Split name for the dataset ('training', 'validation' or 'test'). Defaults to 'training'.
         f : float
-            The center frequency or list of frequencies of the dataset. If None, all frequencies are included.
+            The center frequency or list of frequencies of the dataset.
+            If None, all frequencies are included.
         num : integer
             Controls the width of the frequency bands considered; defaults to
             0 (single frequency line).
@@ -363,7 +383,12 @@ if TF_FLAG:
 
             # save the dataset
             dataset = DatasetSynthetic().save_tfrecord(
-                f=f, num=num, split='training', size=10, features=features, name='/tmp/example.tfrecord'
+                f=f,
+                num=num,
+                split='training',
+                size=10,
+                features=features,
+                name='/tmp/example.tfrecord',
             )
         """
         pipeline = self.get_pipeline_instance()
@@ -397,9 +422,11 @@ if TF_FLAG:
         Parameters
         ----------
         features : list
-            List of features included in the dataset. The features "seeds" and "idx" are always included.
+            List of features included in the dataset.
+            The features "seeds" and "idx" are always included.
         f : float
-            The center frequency or list of frequencies of the dataset. If None, all frequencies are included.
+            The center frequency or list of frequencies of the dataset.
+            If None, all frequencies are included.
         num : integer
             Controls the width of the frequency bands considered; defaults to
             0 (single frequency line).
@@ -435,13 +462,15 @@ if TF_FLAG:
         Parameters
         ----------
         features : list
-            List of features included in the dataset. The features "seeds" and "idx" are always included.
+            List of features included in the dataset.
+            The features "seeds" and "idx" are always included.
         size : int
             Size of the dataset (number of source cases).
         split : str
             Split name for the dataset ('training', 'validation' or 'test'). Defaults to 'training'.
         f : float
-            The center frequency or list of frequencies of the dataset. If None, all frequencies are included.
+            The center frequency or list of frequencies of the dataset.
+            If None, all frequencies are included.
         num : integer
             Controls the width of the frequency bands considered; defaults to
             0 (single frequency line).
@@ -462,8 +491,9 @@ if TF_FLAG:
         Returns
         -------
         tf.data.Dataset
-            TensorFlow dataset containing the generated data. The dataset elements have the structure defined
-            by the output_signature, which is based on the shapes of dataset features.
+            TensorFlow dataset containing the generated data. The dataset elements have
+            the structure defined by the output_signature, which is based on the shapes
+            of dataset features.
         """
         pipeline = self.get_pipeline_instance()
         # self._setup_logging(pipeline=pipeline)
@@ -484,8 +514,9 @@ if TF_FLAG:
         """Get a parser function for a TFRecord dataset.
 
         The parser function can be used to parse the TFRecord dataset into a TensorFlow dataset.
-        Complex-valued features of the dataset are encoded as two real-valued float32 features (real and imaginary part) stacked at
-        the least axis of the array. The parser function decodes the features back to complex-valued features.
+        Complex-valued features of the dataset are encoded as two real-valued float32
+        features (real and imaginary part) stacked at the least axis of the array.
+        The parser function decodes the features back to complex-valued features.
         It can be used as follows:
 
         Parameters
@@ -493,7 +524,8 @@ if TF_FLAG:
         features : list
             List of features included in the dataset.
         f : float
-            The center frequency or list of frequencies of the dataset. If None, all frequencies are included.
+            The center frequency or list of frequencies of the dataset.
+            If None, all frequencies are included.
         num : integer
             Controls the width of the frequency bands considered; defaults to
             0 (single frequency line).
@@ -527,7 +559,12 @@ if TF_FLAG:
 
             # save the dataset
             dataset = DatasetSynthetic().save_tfrecord(
-                f=f, num=num, split='training', size=10, features=features, name='/tmp/example.tfrecord'
+                f=f,
+                num=num,
+                split='training',
+                size=10,
+                features=features,
+                name='/tmp/example.tfrecord',
             )
 
             # parse the dataset

--- a/src/acoupipe/datasets/utils.py
+++ b/src/acoupipe/datasets/utils.py
@@ -223,7 +223,8 @@ def get_frequency_index_range(freq, f, num):
     Parameters
     ----------
     freq : numpy.array
-        frequency vector (can be determined by evaluating `freqdata()` method at a `acoular.PowerSpectra` instance)
+        frequency vector (can be determined by evaluating `freqdata()` method
+        at a `acoular.PowerSpectra` instance)
     f : float
         the frequency (or center frequency) of interest
     num : int
@@ -275,7 +276,7 @@ def get_frequency_index_range(freq, f, num):
 
 
 def set_pipeline_seeds(pipeline, start_idx, size, dataset='training'):
-    """Create the random seed list for each of the sampler objects that is held by the pipeline object.
+    """Create the random seed list for each sampler object held by the pipeline.
 
     Parameters
     ----------


### PR DESCRIPTION
Reflows over-long docstrings and `#:` comments in datasets/base.py and datasets/utils.py to satisfy the 100/120 limits, and removes the corresponding E501/W505 per-file guards. Docstring code examples use one-arg-per-line with a magic trailing comma so the docstring formatter keeps them expanded instead of rejoining — no example code values were changed.

Closes #63