### PR TITLE
Fix example linting

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Example scripts for acoupipe."""

--- a/examples/micgeom_sampling_example.py
+++ b/examples/micgeom_sampling_example.py
@@ -1,3 +1,5 @@
+"""Demonstrate microphone geometry perturbation sampling."""
+
 from pathlib import Path
 
 import acoular as ac

--- a/examples/pipeline_write_h5_example.py
+++ b/examples/pipeline_write_h5_example.py
@@ -47,7 +47,7 @@ bb = ac.BeamformerBase(freq_data=ps, steer=st)
 
 
 # create a feature extraction function
-def extract_features(sampler, beamformer, whitenoise):
+def extract_features(_sampler, beamformer, _whitenoise):
     """Extract features from sampler object."""
     return {'rms': wn.rms, 'sourcemap': beamformer.synthetic(1000, 1)}
 

--- a/examples/point_source_example.py
+++ b/examples/point_source_example.py
@@ -1,3 +1,5 @@
+"""Demonstrate source, position, and source-set sampling."""
+
 from pathlib import Path
 
 import acoular as ac
@@ -10,8 +12,8 @@ from pylab import colorbar, figure, imshow, plot, show
 ac.config.global_caching = 'none'
 
 rng1 = np.random.RandomState(1)  # scipy listens to numpy random seed (when scipy seed is None)
-rng2 = np.random.RandomState(2)  #
-rng3 = np.random.RandomState(3)  #
+rng2 = np.random.RandomState(2)
+rng3 = np.random.RandomState(3)
 
 z = 0.5  # distance between array and source plane
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,12 +140,6 @@ extend-ignore = [
 "src/acoupipe/datasets/experimental.py" = ["ARG002", "ARG004", "D102", "D412", "D413", "D416", "D417", "E501", "N806", "S101", "SLF001", "W505"]
 "src/acoupipe/datasets/ir.py"          = ["D100", "D103", "D413", "D417", "E501", "N806", "W505"]
 
-# --- 14 examples ---
-"examples/micgeom_sampling_example.py"   = ["D100", "INP001"]
-"examples/numeric_attribute_sampling.py" = ["D212"]
-"examples/pipeline_writeH5_example.py"   = ["ARG001", "D212", "INP001"]
-"examples/point_source_example.py"       = ["D100", "INP001"]
-
 # --- app ---
 "app/main.py" = ["A002", "D100", "D103", "DTZ005", "E501", "INP001", "PLC0415"]  # PLC0415 = intentional lazy CLI import
 


### PR DESCRIPTION
## Summary

This PR addresses #71 by bringing the example scripts under Acoular-style targeted linting without changing source or test code.

Relates to:
- #56 
- #71

## What changed

- added `examples/__init__.py` to avoid implicit namespace package lint findings
- added module docstrings to example modules that were missing them
- renamed `examples/pipeline_writeH5_example.py` to `examples/pipeline_write_h5_example.py` to satisfy module naming rules
- renamed unused callback parameters in the pipeline example to underscore-prefixed names
- removed empty trailing comments in `examples/point_source_example.py`
- removed now-unnecessary example-specific Ruff ignores from `pyproject.toml`
