### PR TITLE
Fix logging linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ extend-exclude = ["docs/source"]   # shared config's exclude resolves to its own
 [tool.ruff.lint]
 extend-ignore = [
     # ===== Temporary migration guards (removed in the noted sub-issue) =====
-    "G004", "LOG015",                    # 11  logging
+    "G004",                              # 11  logging
     "PGH004", "RUF100", "E741",          # 10  stale-noqa cleanup / ambiguous names
     # no dedicated sub-issue -> general code cleanup, remove last
     "RUF015", "RUF021", "C419", "SIM108", "SIM114",  # 15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ extend-exclude = ["docs/source"]   # shared config's exclude resolves to its own
 [tool.ruff.lint]
 extend-ignore = [
     # ===== Temporary migration guards (removed in the noted sub-issue) =====
-    "G004",                              # 11  logging
     "PGH004", "RUF100", "E741",          # 10  stale-noqa cleanup / ambiguous names
     # no dedicated sub-issue -> general code cleanup, remove last
     "RUF015", "RUF021", "C419", "SIM108", "SIM114",  # 15

--- a/src/acoupipe/datasets/utils.py
+++ b/src/acoupipe/datasets/utils.py
@@ -432,13 +432,13 @@ def log_execution_time(f):
 
     @wraps(f)
     def wrap(self, *args, **kw):
-        self.logger.info(f'id {self._idx}: start task.')
+        self.logger.info('id %s: start task.', self._idx)
         start = time()
         result = f(self, *args, **kw)
         end = time()
-        self.logger.info(f'id {self._idx}: finished task.')
+        self.logger.info('id %s: finished task.', self._idx)
         # self.logger.info(f"{f.__name__} args:[{args}] took: {end-start:.32f} sec")
-        self.logger.info(f'id {self._idx}: executing task took: {end - start:.32f} sec')
+        self.logger.info('id %s: executing task took: %.32f sec', self._idx, end - start)
         return result
 
     return wrap

--- a/src/acoupipe/pipeline.py
+++ b/src/acoupipe/pipeline.py
@@ -81,13 +81,13 @@ def log_execution_time(f):
 
     @wraps(f)
     def wrap(self, *args, **kw):
-        self.logger.info(f'id {self._idx}: start task.')
+        self.logger.info('id %s: start task.', self._idx)
         start = time()
         result = f(self, *args, **kw)
         end = time()
-        self.logger.info(f'id {self._idx}: finished task.')
+        self.logger.info('id %s: finished task.', self._idx)
         # self.logger.info(f"{f.__name__} args:[{args}] took: {end-start:.32f} sec")
-        self.logger.info(f'id {self._idx}: executing task took: {end - start:.32f} sec')
+        self.logger.info('id %s: executing task took: %.32f sec', self._idx, end - start)
         return result
 
     return wrap
@@ -317,7 +317,11 @@ class SamplerActor:
     def __init__(self, sampler, feature_func):
         # IMPORTANT: do NOT import gpuRIR before this point anywhere.
         gpu_ids = ray.get_gpu_ids()  # e.g. [3]
-        logger.error(f'ray.get_gpu_ids() = {gpu_ids}, CUDA_VISIBLE_DEVICES = {os.environ.get("CUDA_VISIBLE_DEVICES")}')
+        logger.error(
+            'ray.get_gpu_ids() = %s, CUDA_VISIBLE_DEVICES = %s',
+            gpu_ids,
+            os.environ.get('CUDA_VISIBLE_DEVICES'),
+        )
 
         self.sampler = sampler
         self.feature_func = feature_func
@@ -394,14 +398,14 @@ class DistributedPipeline(BasePipeline):
     remote_args = Dict()
 
     def _log_execution_time(self, task_index, times, pid):
-        self.logger.info(f'id {task_index} on pid {pid}: scheduling task took: {times[1] - times[0]:.32f} sec')
-        self.logger.info(f'id {task_index} on pid {pid}: executing task took: {times[2] - times[1]:.32f} sec')
-        self.logger.info(f'id {task_index} on pid {pid}: retrieving result took: {times[3] - times[2]:.32f} sec')
-        self.logger.info(f'id {task_index} on pid {pid}: full time: {times[3] - times[0]:.32f} sec')
+        self.logger.info('id %s on pid %s: scheduling task took: %.32f sec', task_index, pid, times[1] - times[0])
+        self.logger.info('id %s on pid %s: executing task took: %.32f sec', task_index, pid, times[2] - times[1])
+        self.logger.info('id %s on pid %s: retrieving result took: %.32f sec', task_index, pid, times[3] - times[2])
+        self.logger.info('id %s on pid %s: full time: %.32f sec', task_index, pid, times[3] - times[0])
         # self.logger.info(f"{f.__name__} args:[{args}] took: {end - start:.4f} sec")
 
     def _sample_and_schedule_task(self, actor, task_dict):
-        self.logger.info(f'id {self._idx}: start task.')
+        self.logger.info('id %s: start task.', self._idx)
         times = [time(), None, None, None]  # (schedule timestamp, execution timestamp, stop timestamp, get timestamp)
         if callable(self.features):
             result_id = actor.extract_features.remote(self._seeds, times)  # calculation is started in new remote task
@@ -469,12 +473,12 @@ class DistributedPipeline(BasePipeline):
                     try:
                         data, times, pid = ray.get(did)
                     except Exception as exception:
-                        self.logger.info(f'task with id {task_dict[did]} failed with Traceback:', exc_info=True)
+                        self.logger.info('task with id %s failed with Traceback:', task_dict[did], exc_info=True)
                         raise exception
                     times[-1] = time()  # add getter time
                     actor, new_data = task_dict.pop(did)
                     data.update(new_data)  # add the remaining task_dict items to the data dict
-                    self.logger.info(f'id {data["idx"]} on pid {pid}: finished task.')
+                    self.logger.info('id %s on pid %s: finished task.', data['idx'], pid)
                     self._log_execution_time(data['idx'], times, pid)
                     if (nsamples + start_idx - 1 - self._idx) > 0:  # directly _schedule next task
                         self._update_sample_index_and_seeds(seed_iter)

--- a/src/acoupipe/pipeline.py
+++ b/src/acoupipe/pipeline.py
@@ -71,6 +71,8 @@ from numpy.random import RandomState, default_rng
 from tqdm import tqdm
 from traits.api import Callable, Dict, Either, Instance, Int, Property, Tuple
 
+logger = logging.getLogger(__name__)
+
 
 # Without the use of this decorator factory (wraps), the name of the
 # function 'f' would have been 'wrap', and the docstring of the original f() would have been lost.
@@ -315,7 +317,7 @@ class SamplerActor:
     def __init__(self, sampler, feature_func):
         # IMPORTANT: do NOT import gpuRIR before this point anywhere.
         gpu_ids = ray.get_gpu_ids()  # e.g. [3]
-        logging.error(f'ray.get_gpu_ids() = {gpu_ids}, CUDA_VISIBLE_DEVICES = {os.environ.get("CUDA_VISIBLE_DEVICES")}')
+        logger.error(f'ray.get_gpu_ids() = {gpu_ids}, CUDA_VISIBLE_DEVICES = {os.environ.get("CUDA_VISIBLE_DEVICES")}')
 
         self.sampler = sampler
         self.feature_func = feature_func


### PR DESCRIPTION
## Summary

This PR addresses #68 by resolving source logging lint findings in `src/acoupipe`.

Related issue:
- #56 
- #68

## What changed

- replaced a root logger call in `src/acoupipe/pipeline.py` with a module logger
- added a module-level logger via `logging.getLogger(__name__)`
- converted logging f-strings to lazy logger formatting in:
  - `src/acoupipe/pipeline.py`
  - `src/acoupipe/datasets/utils.py`

## Note
This PR does not address the wish for a Acoular-native logger as stated in [#68](https://github.com/adku1173/acoupipe/issues/68#issuecomment-4637577111).